### PR TITLE
Fix root custom tag syntax highlight

### DIFF
--- a/syntax/riot.vim
+++ b/syntax/riot.vim
@@ -20,7 +20,7 @@ unlet! b:current_syntax
 " --- dependencies ---
 
 syntax region riotCustomTag
-  \ start=+^<\z([^ /!?<>"']\+\)>+
+  \ start=+^<\z([^ /!?<>"']\+\)\%(\s\+[^>]*\)\?>+
   \ end=+^</\z1>+
   \ keepend
   \ contains=customTag,styleRegion,scriptRegion,@JS,htmlRegion,customEndTag,javaScriptExpression
@@ -33,8 +33,9 @@ syntax region topLevelComment
   \ contains=htmlComment
 
 syntax match customTag
-  \ +^<[^ /!?<>"']\+>+
+  \ +^<[^ /!?<>"']\+\%(\s\+[^>]*\)\?>+
   \ contained
+  \ contains=htmlString,jsBlock
 
 syntax match customEndTag
   \ +^</[^ /!?<>"']\+>+


### PR DESCRIPTION
#3 

Enable to add attributes to custom tags.
However, not quoted attribute value like `foo` in `id=foo` doesn't be colored correctly. I don't know how to fix this.

The `customTag`'s regexp is based on the fork [lambdalisue/vim-riot](https://github.com/lambdalisue/vim-riot). Thank you for the forking!